### PR TITLE
Allow to specify config and requirements paths

### DIFF
--- a/scripts/st2-check-pylint-pack
+++ b/scripts/st2-check-pylint-pack
@@ -69,10 +69,10 @@ if [ "${PYTHON_FILE_COUNT}" == "0" ]; then
 fi
 
 # Install per-pack dependencies
-pip install --cache-dir ${HOME}/.pip-cache -q -r requirements-dev.txt
+pip install --cache-dir ${HOME}/.pip-cache -q -r ${REQUIREMENTS_DIR}requirements-dev.txt
 
 # Install test dependencies
-pip install --cache-dir ${HOME}/.pip-cache -q -r requirements-pack-tests.txt
+pip install --cache-dir ${HOME}/.pip-cache -q -r ${REQUIREMENTS_DIR}requirements-pack-tests.txt
 
 # Install pack dependencies
 if [ -f ${PACK_REQUIREMENTS_FILE} ]; then

--- a/scripts/st2-check-pylint-pack
+++ b/scripts/st2-check-pylint-pack
@@ -96,7 +96,7 @@ else
 fi
 
 if [ ${ACTION_PYTHON_FILES_COUNT} -gt 0 ]; then
-    find ${PACK_PATH}/actions -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=./lint-configs/python/.pylintrc && echo "--> No pylint issues found in actions." || exit $?
+    find ${PACK_PATH}/actions -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=${CONFIG_DIR:-./lint-configs/}python/.pylintrc && echo "--> No pylint issues found in actions." || exit $?
 fi
 
 if [ -d ${PACK_PATH}/sensors ]; then
@@ -106,7 +106,7 @@ else
 fi
 
 if [ ${SENSOR_PYTHON_FILES_COUNT} -gt 0 ]; then
-    find ${PACK_PATH}/sensors -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=./lint-configs/python/.pylintrc && echo "--> No pylint issues found in sensors." || exit $?
+    find ${PACK_PATH}/sensors -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=${CONFIG_DIR:-./lint-configs/}python/.pylintrc && echo "--> No pylint issues found in sensors." || exit $?
 fi
 
 if [ -d ${PACK_PATH}/etc ]; then
@@ -116,5 +116,5 @@ else
 fi
 
 if [ ${ETC_PYTHON_FILES_COUNT} -gt 0 ]; then
-    find ${PACK_PATH}/etc -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=./lint-configs/python/.pylintrc && echo "--> No pylint issues found in etc." || exit $?
+    find ${PACK_PATH}/etc -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=${CONFIG_DIR:-./lint-configs/}python/.pylintrc && echo "--> No pylint issues found in etc." || exit $?
 fi

--- a/scripts/st2-check-register-pack-resources
+++ b/scripts/st2-check-register-pack-resources
@@ -38,7 +38,7 @@ if [ ! -d ${PACK_DIR} ]; then
 fi
 
 PACK_PATH=$1
-PACK_NAME=$(basename ${PACK_PATH})
+PACK_NAME=${PACK_NAME:-$(basename ${PACK_PATH})}
 
 ST2_REPO_PATH=${ST2_REPO_PATH:-/tmp/st2}
 ST2_COMPONENTS=$(get_st2_components)


### PR DESCRIPTION
With single-pack CI checks we can no longer assume lint-configs and global requirements in the checkout dir, so this PR adds the ability to configure the paths through env variables. 

The variables are either optional or default to old values, so the script is still compatible with st2contrib.
