### PR TITLE
corrected problems about initial pack.yaml

### DIFF
--- a/st2sdk/templates/pack.yaml
+++ b/st2sdk/templates/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name: {{ pack_name }}
 description: ''
-version: 0.1
+version: 0.1.0
 author: {{ author_name }}
 email: {{ author_email }}

--- a/st2sdk/templates/pack.yaml
+++ b/st2sdk/templates/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name: {{ pack_name }}
-description:
+description: ''
 version: 0.1
 author: {{ author_name }}
 email: {{ author_email }}


### PR DESCRIPTION
Currently, initial `pack.yaml` which is just after generated by `st2sdk bootstrap` has two problems.

* fails to register trigger of created pack because of raising an exception of `ValidationError`.
* outpus warning of the version parameter format that will not be suported in near future.

This patch corrects these problems.

The reproduction method is here.
```sh
vagrant@st2-node:~$ st2sdk bootstrap foo
2016-12-26 11:06:08,375 INFO Pack "foo" created in /home/vagrant/foo
vagrant@st2-node:~$ sudo cp -r foo /opt/stackstorm/packs/
vagrant@st2-node:~$ st2 run packs.setup_virtualenv packs=foo
..
id: 5860f9b86f086f26db26bc07
status: succeeded
parameters: 
  packs:
  - foo
result: 
  exit_code: 0
  result: 'Successfuly set up virtualenv for the following packs: foo'
  stderr: 'st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Setting up virtualenv for pack "foo"

    st2.actions.python.SetupVirtualEnvironmentAction: INFO     Virtualenv path "/opt/stackstorm/virtualenvs/foo" doesn''t exist

    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Creating virtualenv for pack "foo" in "/opt/stackstorm/virtualenvs/foo"

    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Creating virtualenv in "/opt/stackstorm/virtualenvs/foo" using Python binary "/opt/stackstorm/st2/bin/python"

    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Running command "/opt/stackstorm/st2/bin/virtualenv -p /opt/stackstorm/st2/bin/python --always-copy /opt/stackstorm/virtualenvs/foo" to create virtualenv.

    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Installing base requirements

    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    No pack specific requirements found

    st2.actions.python.SetupVirtualEnvironmentAction: DEBUG    Virtualenv for pack "foo" successfully created in "/opt/stackstorm/virtualenvs/foo"

    '
  stdout: ''
vagrant@st2-node:~$ sudo st2ctl reload --register-triggers
Registering content...[flags = --register-triggers]
2016-12-26 11:06:55,588 INFO [-] Connecting to database "st2" @ "0.0.0.0:27017" as user "None".
2016-12-26 11:06:55,696 INFO [-] =========================================================
2016-12-26 11:06:55,697 INFO [-] ############## Registering triggers #####################
2016-12-26 11:06:55,697 INFO [-] =========================================================
2016-12-26 11:06:55,837 WARNING [-] Pack "foo" contains invalid semver version specifer, casting it to a full semver version specifier (0.1 -> 0.1.0).
Short versions will become INVALID in StackStorm 2.2, and the pack will stop working. Update the pack version in "pack.yaml".
2016-12-26 11:06:55,841 ERROR [-] Failed to register pack "foo"
Traceback (most recent call last):
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/bootstrap/base.py", line 120, in register_pack
    pack_db, _ = self._register_pack(pack_name=pack_name, pack_dir=pack_dir)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/bootstrap/base.py", line 135, in _register_pack
    pack_db = self._register_pack_db(pack_name=pack_name, pack_dir=pack_dir)
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/bootstrap/base.py", line 160, in _register_pack_db
    pack_api.validate()
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2common/models/api/pack.py", line 184, in validate
    raise e
ValidationError: None is not of type 'string'

Failed validating 'type' in schema['properties']['description']:
    {'description': 'Brief description of the pack and the service it integrates with.',
     'required': True,
     'type': 'string'}

On instance['description']:
    None
2016-12-26 11:06:55,843 INFO [-] Registered 0 triggers.
##### st2 components status #####
st2actionrunner PID: 1007
st2actionrunner PID: 1044
st2api PID: 888
st2api PID: 9947
st2stream PID: 889
st2stream PID: 1348
st2auth PID: 870
st2auth PID: 3501
st2garbagecollector PID: 864
st2notifier PID: 881
st2resultstracker PID: 872
st2rulesengine PID: 885
st2rulesengine PID: 22704
st2rulesengine PID: 22705
st2sensorcontainer PID: 852
st2chatops is not running.
mistral-server PID: 1023
mistral-api PID: 989
mistral-api PID: 22538
mistral-api PID: 22539
vagrant@st2-node:~$ 
```