### PR TITLE
Add new "ST2_INSTALL_DEPS" environment variable to all the scripts

### DIFF
--- a/scripts/st2-check-pylint-pack
+++ b/scripts/st2-check-pylint-pack
@@ -31,6 +31,10 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
+# If "1" it will be assumed various dependencies are already installed and won't
+# be installed again (e.g. when running on StackStorm Exchange Circle CI)
+ST2_INSTALL_DEPS=${ST2_INSTALL_DEPS:-1}
+
 PACK_DIR=$1
 PACK_NAME=$(basename ${PACK_DIR})
 
@@ -68,22 +72,24 @@ if [ "${PYTHON_FILE_COUNT}" == "0" ]; then
     exit 0
 fi
 
-# Install per-pack dependencies
-pip install --cache-dir ${HOME}/.pip-cache -q -r ${REQUIREMENTS_DIR}requirements-dev.txt
+if [ "${ST2_INSTALL_DEPS}" = "1" ]; then
+    # Install per-pack dependencies
+    pip install --cache-dir ${HOME}/.pip-cache -q -r ${REQUIREMENTS_DIR}requirements-dev.txt
 
-# Install test dependencies
-pip install --cache-dir ${HOME}/.pip-cache -q -r ${REQUIREMENTS_DIR}requirements-pack-tests.txt
+    # Install test dependencies
+    pip install --cache-dir ${HOME}/.pip-cache -q -r ${REQUIREMENTS_DIR}requirements-pack-tests.txt
 
-# Install pack dependencies
-if [ -f ${PACK_REQUIREMENTS_FILE} ]; then
-    echo "Installing pack requirements from ${PACK_REQUIREMENTS_FILE}..."
-    pip install --cache-dir ${HOME}/.pip-cache -q -r ${PACK_REQUIREMENTS_FILE}
-fi
+    # Install pack dependencies
+    if [ -f ${PACK_REQUIREMENTS_FILE} ]; then
+        echo "Installing pack requirements from ${PACK_REQUIREMENTS_FILE}..."
+        pip install --cache-dir ${HOME}/.pip-cache -q -r ${PACK_REQUIREMENTS_FILE}
+    fi
 
-# Install pack test dependencies (if any)
-if [ -f ${PACK_TESTS_REQUIREMENTS_FILE} ]; then
-    echo "Installing pack test requirements from ${PACK_TESTS_REQUIREMENTS_FILE}..."
-    pip install --cache-dir ${HOME}/.pip-cache -q -r ${PACK_TESTS_REQUIREMENTS_FILE}
+    # Install pack test dependencies (if any)
+    if [ -f ${PACK_TESTS_REQUIREMENTS_FILE} ]; then
+        echo "Installing pack test requirements from ${PACK_TESTS_REQUIREMENTS_FILE}..."
+        pip install --cache-dir ${HOME}/.pip-cache -q -r ${PACK_TESTS_REQUIREMENTS_FILE}
+    fi
 fi
 
 export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}

--- a/scripts/st2-check-register-pack-resources
+++ b/scripts/st2-check-register-pack-resources
@@ -34,6 +34,10 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
+# If "1" it will be assumed various dependencies are already installed and won't
+# be installed again (e.g. when running on StackStorm Exchange Circle CI)
+ST2_INSTALL_DEPS=${ST2_INSTALL_DEPS:-1}
+
 PACK_DIR=$1
 PACK_NAME=${PACK_NAME:-$(basename ${PACK_DIR})}
 ST2_CONFIG_FILE=${ST2_CONFIG_FILE:-${SCRIPT_PATH}/st2.tests.conf}
@@ -60,8 +64,10 @@ else
     REGISTER_SCRIPT_REGISTER_FLAGS="--register-all"
 fi
 
-# Install st2 dependencies
-pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/requirements.txt
+if [ "${ST2_INSTALL_DEPS}" = "1" ]; then
+    # Install st2 dependencies
+    pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/requirements.txt
+fi
 
 # Set PYTHONPATH to include st2 components
 export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}

--- a/scripts/st2-check-validate-pack-example-config
+++ b/scripts/st2-check-validate-pack-example-config
@@ -34,6 +34,10 @@ if [ $# -ne 1 ]; then
     exit 1
 fi
 
+# If "1" it will be assumed various dependencies are already installed and won't
+# be installed again (e.g. when running on StackStorm Exchange Circle CI)
+ST2_INSTALL_DEPS=${ST2_INSTALL_DEPS:-1}
+
 PACK_DIR=$1
 PACK_NAME=${PACK_NAME:-$(basename ${PACK_DIR})}
 
@@ -53,7 +57,9 @@ CONFIG_SCHEMA_FILE=$(find ${PACK_DIR}/config.schema.yaml 2> /dev/null)
 EXAMPLE_CONFIG_FILE=$(find ${PACK_DIR}/*.yaml.example 2> /dev/null)
 
 # Install st2 dependencies
-pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/requirements.txt
+if [ "${ST2_INSTALL_DEPS}" = "1" ]; then
+    pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/requirements.txt
+fi
 
 # Set PYTHONPATH to include st2 components
 export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}

--- a/st2sdk/__init__.py
+++ b/st2sdk/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.3.4'
+__version__ = '0.4.0'


### PR DESCRIPTION
With this variable, user can control if various StackStorm deps are installed inside the script or not.

This comes handy when invoking those scripts where those deps are already installed (e.g. on StackStorm Exchange Circle CI jobs).

Without that option, we are installing those deps twice on Exchange CI (once inside the CI job and then again inside those scripts).