### PR TITLE
Fix setup.py requiring six module

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v0.5.1 - July 28th, 2019
+------------------------
+* Fix bug in ``setup.py`` requiring the ``six`` library before it was actually installed.
+
 v0.5.0 - July 28th, 2019
 ------------------------
 

--- a/README.rst
+++ b/README.rst
@@ -189,7 +189,7 @@ Usage:
 Copyright, License, and Contributors Agreement
 ----------------------------------------------
 
-Copyright 2015 StackStorm, Inc.
+Copyright 2019 StackStorm, Inc.
 
 Licensed under the Apache License, Version 2.0 (the “License”); you may
 not use this work except in compliance with the License. You may obtain

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,6 @@ import os
 import sys
 import io
 
-import six
 from setuptools import setup, find_packages
 
 
@@ -42,7 +41,9 @@ def get_requirements():
 
     # NOTE: We use latest version under Python 3
     required = [l for l in required if not l.startswith('cmd2')]
-    if six.PY2:
+    # same as six.PY2, but we can't use six in setup.py  because it isn't
+    # garaunteed to be in a fresh virtualenv before installing this package
+    if sys.version_info[0] == 2:
         required.append('cmd2>=0.8.9,<0.9')
     else:
         required.append('cmd2>=0.9.i5,<0.10')

--- a/st2sdk/__init__.py
+++ b/st2sdk/__init__.py
@@ -13,4 +13,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-__version__ = '0.5.0'
+__version__ = '0.5.1'


### PR DESCRIPTION
For the last 2 days we've been seeing errors like this in our CI/CD pipelines:

```
    ----------------------------------------[0m
[31mERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.[0m
[31m    ERROR: Command errored out with exit status 1:
     command: /ci_stackstorm/packs/stackstorm-patching_encore/ci/virtualenv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/ci_stackstorm/packs/stackstorm-patching_encore/ci/virtualenv/src/st2sdk/setup.py'"'"'; __file__='"'"'/ci_stackstorm/packs/stackstorm-patching_encore/ci/virtualenv/src/st2sdk/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info
         cwd: /ci_stackstorm/packs/stackstorm-patching_encore/ci/virtualenv/src/st2sdk/
    Complete output (5 lines):
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/ci_stackstorm/packs/stackstorm-patching_encore/ci/virtualenv/src/st2sdk/setup.py", line 21, in <module>
        import six
    ImportError: No module named six
    ----------------------------------------[0m
```

It appears to be caused by https://github.com/StackStorm/st2sdk/commit/6fdfe4b1f7de47571089ed6f6330fa772f7faec3#diff-b4ef698db8ca845e5845c4618278f29a 

In `setup.py` we now `import six` and since `six` isn't necessarily installed in the `virtualenv` before installing `st2sdk` the installation fails.

This simple changes removes the dependency on `six` from `setup.py` so we should be able to install `st2sdk` like before.

@Kami can you check this out?