### PR TITLE
Improve tests to detect more setup.py issues

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import six
 import os
 import sys
 import io

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import six
 import os
 import sys
 import io

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,10 @@ commands = rm -rf /tmp/{envname}-checks
 # us to write directly to the directory where the code is checked out to (python
 # setup.py sdist writes <package>.egg-info directory in a working dir where it's ran from)
 [testenv:py27-sdist]
+# NOTE: We explicitly specify empts deps to ensure no other dependencies are
+# installed in that virtualenv and verify installation works on a fresh system
+# without any dependencies
+deps =
 basepython = python2.7
 changedir = /tmp
 commands = rm -rf /tmp/py2-sdist
@@ -33,6 +37,10 @@ commands = rm -rf /tmp/py2-sdist
            rm -rf {toxinidir}/st2sdk/__pycache__
 
 [testenv:py36-sdist]
+# NOTE: We explicitly specify empts deps to ensure no other dependencies are
+# installed in that virtualenv and verify installation works on a fresh system
+# without any dependencies
+deps =
 basepython = python3.6
 changedir = /tmp
 commands = rm -rf /tmp/py3-sdist


### PR DESCRIPTION
This pull request improves existing sdist tests so they also uncover issues which are related to ``setup.py`` depending on a 3rd party library such as the one inadvertently introduced in #27.

```bash
kami ~/w/stackstorm/st2sdk (git:master)$ tox -e py36-sdist
py36-sdist create: /home/kami/w/stackstorm/st2sdk/.tox/py36-sdist
py36-sdist installed: You are using pip version 9.0.1, however version 19.2.1 is available.,You should consider upgrading via the 'pip install --upgrade pip' command.,st2sdk==0.5.0
py36-sdist run-test-pre: PYTHONHASHSEED='3826356398'
py36-sdist run-test: commands[0] | rm -rf /tmp/py3-sdist
py36-sdist run-test: commands[1] | cp -r /home/kami/w/stackstorm/st2sdk /tmp/py3-sdist
py36-sdist run-test: commands[2] | python /tmp/py3-sdist/setup.py sdist --formats=zip
Traceback (most recent call last):
  File "py3-sdist/setup.py", line 17, in <module>
    import six
ModuleNotFoundError: No module named 'six'
```

Before, those checks would pass since ``six`` dependency was being installed in the virtual environment where that check runs.