### PR TITLE
Use separate pylintrc for Exchange pack checks

### DIFF
--- a/scripts/st2-check-pylint-pack
+++ b/scripts/st2-check-pylint-pack
@@ -105,7 +105,7 @@ else
 fi
 
 if [ ${ACTION_PYTHON_FILES_COUNT} -gt 0 ]; then
-    find ${PACK_DIR}/actions -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=${CONFIG_DIR:-./lint-configs/}python/.pylintrc && echo "--> No pylint issues found in actions." || exit $?
+    find ${PACK_DIR}/actions -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=${CONFIG_DIR:-./lint-configs/}python/.pylintrc-exchange && echo "--> No pylint issues found in actions." || exit $?
 fi
 
 if [ -d ${PACK_DIR}/sensors ]; then
@@ -115,7 +115,7 @@ else
 fi
 
 if [ ${SENSOR_PYTHON_FILES_COUNT} -gt 0 ]; then
-    find ${PACK_DIR}/sensors -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=${CONFIG_DIR:-./lint-configs/}python/.pylintrc && echo "--> No pylint issues found in sensors." || exit $?
+    find ${PACK_DIR}/sensors -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=${CONFIG_DIR:-./lint-configs/}python/.pylintrc-exchange && echo "--> No pylint issues found in sensors." || exit $?
 fi
 
 if [ -d ${PACK_DIR}/etc ]; then
@@ -125,5 +125,5 @@ else
 fi
 
 if [ ${ETC_PYTHON_FILES_COUNT} -gt 0 ]; then
-    find ${PACK_DIR}/etc -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=${CONFIG_DIR:-./lint-configs/}python/.pylintrc && echo "--> No pylint issues found in etc." || exit $?
+    find ${PACK_DIR}/etc -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=${CONFIG_DIR:-./lint-configs/}python/.pylintrc-exchange && echo "--> No pylint issues found in etc." || exit $?
 fi


### PR DESCRIPTION
Uses https://github.com/StackStorm/lint-configs/blob/master/python/.pylintrc-exchange, which adds `lib` to `ignored-modules`.

This is necessary for Python 3, which does not allow implicit relative imports. However, for each action in a pack, ST2 itself adds `actions/lib` to `PYTHONPACK`, so what looks like an implicit relative import is not actually.

For testing, since that module is not actually importable, pylint needs to be told to ignore that "missing" module.

This should fix the following Python 3 pack build failures:

* [stackstorm-checkpoint](https://circleci.com/gh/StackStorm-Exchange/stackstorm-checkpoint/141)
* [stackstorm-dimensiondata](https://circleci.com/gh/StackStorm-Exchange/stackstorm-dimensiondata/154)
* [stackstorm-octopusdeploy](https://circleci.com/gh/StackStorm-Exchange/stackstorm-octopusdeploy/162)
* [stackstorm-openstack](https://circleci.com/gh/StackStorm-Exchange/stackstorm-openstack/226)
* [stackstorm-paloalto](https://circleci.com/gh/StackStorm-Exchange/stackstorm-paloalto/157)
* [stackstorm-sumologic](https://circleci.com/gh/StackStorm-Exchange/stackstorm-sumologic/150)
* [stacsktorm-yammer](https://circleci.com/gh/StackStorm-Exchange/stackstorm-yammer/156)