### PR TITLE
Update cmd2 dependency for py3.8

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+v0.6.0 - 6 August 2022
+-------------------------
+
+* Update cmd2 version to v0.9.15 or greater for Python3.8 support.
+
 v0.5.2 - November 2, 2019
 -------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ def get_requirements():
     if sys.version_info[0] == 2:
         required.append('cmd2>=0.8.9,<0.9')
     else:
-        required.append('cmd2>=0.9.i5,<0.10')
+        required.append('cmd2>=0.9.15,<0.10')
 
     return required
 
@@ -70,9 +70,9 @@ setup(
         'License :: OSI Approved :: Apache Software License',
         'Operating System :: POSIX :: Linux',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
-        'Programming Language :: Python :: 2.7'
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
WIP to fix CI error

```
   Obtaining st2sdk from git+https://github.com/StackStorm/st2sdk.git@master#egg=st2sdk (from -r /home/runner/work/stackstorm-vault/stackstorm-vault/requirements-dev.txt (line 6))
    Cloning https://github.com/StackStorm/st2sdk.git (to revision master) to /home/runner/virtualenv/src/st2sdk
      ERROR: Command errored out with exit status 1:
       command: /home/runner/virtualenv/bin/python -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/home/runner/virtualenv/src/st2sdk/setup.py'"'"'; __file__='"'"'/home/runner/virtualenv/src/st2sdk/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /tmp/pip-pip-egg-info-3ve5hs7d
           cwd: /home/runner/virtualenv/src/st2sdk/
      Complete output (3 lines):
      error in st2sdk setup command: 'install_requires' must be a string or list of strings containing valid project/version requirement specifiers; Expected end or semicolon (after version specifier)
          cmd2>=0.9.i5,<0.10
              ~~~~~^
```